### PR TITLE
fix: eliminate reflection in ProbeTable.addDriver() to prevent R8 startup crash

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/serialport/ProbeTable.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/serialport/ProbeTable.java
@@ -1,0 +1,73 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.bg7yoz.ft8cn.serialport;
+
+import android.util.Pair;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Maps (vendor id, product id) pairs to the corresponding serial driver.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public class ProbeTable {
+
+    private final Map<Pair<Integer, Integer>, Class<? extends UsbSerialDriver>> mProbeTable =
+            new LinkedHashMap<>();
+
+    /**
+     * Adds or updates a (vendor, product) pair in the table.
+     *
+     * @param vendorId the USB vendor id
+     * @param productId the USB product id
+     * @param driverClass the driver class responsible for this pair
+     * @return {@code this}, for chaining
+     */
+    public ProbeTable addProduct(int vendorId, int productId,
+            Class<? extends UsbSerialDriver> driverClass) {
+        mProbeTable.put(Pair.create(vendorId, productId), driverClass);
+        return this;
+    }
+
+    /**
+     * Registers all (vendorId, productId) pairs in {@code devices} for {@code driverClass}.
+     *
+     * <p>The device map is passed directly rather than obtained via reflection, so R8/ProGuard
+     * does not strip {@code getSupportedDevices()} from release builds — which previously caused
+     * a {@code NoSuchMethodException} crash on startup.
+     *
+     * @param driverClass the driver class
+     * @param devices map from vendor ID to array of product IDs, as returned by
+     *                {@code getSupportedDevices()} on each driver
+     * @return {@code this}, for chaining
+     */
+    ProbeTable addDriver(Class<? extends UsbSerialDriver> driverClass, Map<Integer, int[]> devices) {
+        for (Map.Entry<Integer, int[]> entry : devices.entrySet()) {
+            final int vendorId = entry.getKey();
+            for (int productId : entry.getValue()) {
+                addProduct(vendorId, productId, driverClass);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Returns the driver for the given (vendor, product) pair, or {@code null}
+     * if no match.
+     *
+     * @param vendorId the USB vendor id
+     * @param productId the USB product id
+     * @return the driver class matching this pair, or {@code null}
+     */
+    public Class<? extends UsbSerialDriver> findDriver(int vendorId, int productId) {
+        final Pair<Integer, Integer> pair = Pair.create(vendorId, productId);
+        return mProbeTable.get(pair);
+    }
+
+}

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/serialport/UsbSerialProber.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/serialport/UsbSerialProber.java
@@ -1,0 +1,92 @@
+/* Copyright 2011-2013 Google Inc.
+ * Copyright 2013 mike wakerly <opensource@hoho.com>
+ *
+ * Project home page: https://github.com/mik3y/usb-serial-for-android
+ */
+
+package com.bg7yoz.ft8cn.serialport;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public class UsbSerialProber {
+
+    private final ProbeTable mProbeTable;
+
+    public UsbSerialProber(ProbeTable probeTable) {
+        mProbeTable = probeTable;
+    }
+
+    public static UsbSerialProber getDefaultProber() {
+        return new UsbSerialProber(getDefaultProbeTable());
+    }
+
+    public static ProbeTable getDefaultProbeTable() {
+        final ProbeTable probeTable = new ProbeTable();
+        probeTable.addDriver(CdcAcmSerialDriver.class, CdcAcmSerialDriver.getSupportedDevices());
+        probeTable.addDriver(Cp21xxSerialDriver.class, Cp21xxSerialDriver.getSupportedDevices());
+        probeTable.addDriver(FtdiSerialDriver.class, FtdiSerialDriver.getSupportedDevices());
+        probeTable.addDriver(ProlificSerialDriver.class, ProlificSerialDriver.getSupportedDevices());
+        probeTable.addDriver(Ch34xSerialDriver.class, Ch34xSerialDriver.getSupportedDevices());
+        return probeTable;
+    }
+
+    /**
+     * Finds and builds all possible {@link UsbSerialDriver UsbSerialDrivers}
+     * from the currently-attached {@link UsbDevice} hierarchy. This method does
+     * not require permission from the Android USB system, since it does not
+     * open any of the devices.
+     *
+     * @param usbManager usb manager
+     * @return a list, possibly empty, of all compatible drivers
+     */
+    public List<UsbSerialDriver> findAllDrivers(final UsbManager usbManager) {
+        final List<UsbSerialDriver> result = new ArrayList<>();
+
+        for (final UsbDevice usbDevice : usbManager.getDeviceList().values()) {
+            final UsbSerialDriver driver = probeDevice(usbDevice);
+            if (driver != null) {
+                result.add(driver);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Probes a single device for a compatible driver.
+     *
+     * @param usbDevice the usb device to probe
+     * @return a new {@link UsbSerialDriver} compatible with this device, or
+     *         {@code null} if none available.
+     */
+    public UsbSerialDriver probeDevice(final UsbDevice usbDevice) {
+        final int vendorId = usbDevice.getVendorId();
+        final int productId = usbDevice.getProductId();
+
+        final Class<? extends UsbSerialDriver> driverClass =
+                mProbeTable.findDriver(vendorId, productId);
+        if (driverClass != null) {
+            final UsbSerialDriver driver;
+            try {
+                final Constructor<? extends UsbSerialDriver> ctor =
+                        driverClass.getConstructor(UsbDevice.class);
+                driver = ctor.newInstance(usbDevice);
+            } catch (NoSuchMethodException | IllegalArgumentException | InstantiationException |
+                     IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+            return driver;
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
`ProbeTable.addDriver()` currently uses `Class.getMethod("getSupportedDevices")` to discover a driver's supported USB IDs at runtime. R8, the code shrinker used in release builds, removes static methods that it cannot see being called directly — so `getSupportedDevices()` gets stripped, and the app crashes on startup with `NoSuchMethodException: getSupportedDevices`.

The fix passes the device map directly to `addDriver()`, making the call visible to R8 and removing the reflection entirely. The five call sites in `UsbSerialProber.getDefaultProbeTable()` are updated to match.

This was found and fixed in [TrailDigi](https://codeberg.org/traildigi/traildigi) (a fork of FT8TW). The crash was reported in issue #67 by @BitLoose. Offering it back upstream.

**Changes:**
- `ProbeTable.java`: `addDriver(Class)` → `addDriver(Class, Map<Integer, int[]>)`; reflection imports removed
- `UsbSerialProber.java`: five `addDriver()` calls updated to pass `getSupportedDevices()` explicitly